### PR TITLE
E2-T3: LWW materialization + conformance skeleton (#14)

### DIFF
--- a/docs/lww-materialization.md
+++ b/docs/lww-materialization.md
@@ -1,0 +1,29 @@
+# LWW + Tombstone Materialization (E2)
+
+## Deterministic Resolution Rule
+
+For each logical entity key:
+- Compare `(lamport, author)` tuple.
+- Larger lamport wins.
+- If lamport ties, lexical order of `author` is tie-breaker.
+
+This yields deterministic winner selection across nodes.
+
+## Tombstone Handling
+
+- Delete is represented as tombstone event.
+- A tombstoned key cannot reappear unless a strictly newer winning event exists by tuple rule.
+- Replays must not resurrect stale pre-tombstone values.
+
+## Apply Steps
+
+1. Validate event envelope and signature.
+2. Resolve winner against current entity head using tuple rule.
+3. Update materialized view and tombstone index atomically.
+4. Emit deterministic state delta.
+
+## Invariants
+
+- Same ordered event set => same final materialized state.
+- Duplicate events do not change state after first apply.
+- Tombstone prevents stale value reappearance.

--- a/docs/sync-conformance-tests.md
+++ b/docs/sync-conformance-tests.md
@@ -1,0 +1,36 @@
+# Sync Conformance Tests (A-D)
+
+Minimum: 12 cases (3 per group).
+
+## Group A: Signature and Envelope Validation
+
+- A-01: valid signature accepted
+- A-02: invalid signature rejected with `ERR_SIG_INVALID`
+- A-03: missing required field rejected
+
+## Group B: Idempotency and Integrity
+
+- B-01: duplicate `event_id` accepted as no-op
+- B-02: `event_id` collision with different hash quarantined
+- B-03: replay burst keeps stable state
+
+## Group C: Ordering and LWW/Tombstone
+
+- C-01: out-of-order events converge via tuple rule
+- C-02: lamport tie resolves by `author` lexical order
+- C-03: tombstoned entity does not reappear from stale replay
+
+## Group D: Partition/Rejoin Recovery
+
+- D-01: split-brain + heal converges to same final state
+- D-02: missing range requested via cursor and reconciled
+- D-03: quarantine events remain isolated during re-materialization
+
+## Evidence Format
+
+For each case capture:
+- `test_id`
+- `input_event_sequence`
+- `expected_final_hash`
+- `actual_final_hash`
+- `result`


### PR DESCRIPTION
## Summary
- Add deterministic LWW+tombstone materialization rules.
- Add sync conformance test skeleton A-D with 12 test IDs.

## Issue
- Closes #14

## Stack
- Base PR: #16
