### PR TITLE
#45 PR2: durable fsync/atomic file backend + store wiring

### DIFF
--- a/src/p2p_oplog_replicator/migration/quarantine/store.py
+++ b/src/p2p_oplog_replicator/migration/quarantine/store.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
+
+from p2p_oplog_replicator.persistence.file_backend import DurableJsonLineFileStore
 
 
 @dataclass(frozen=True)
@@ -19,21 +20,13 @@ class QuarantineRecord:
 
 class QuarantineStore:
     def __init__(self, path: Path) -> None:
-        self._path = path
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.touch(exist_ok=True)
+        self._store = DurableJsonLineFileStore(path)
 
     def append(self, record: QuarantineRecord) -> None:
-        with self._path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(asdict(record), sort_keys=True, separators=(",", ":")) + "\n")
+        self._store.append_json_line(asdict(record))
 
     def read_all(self) -> list[QuarantineRecord]:
         out: list[QuarantineRecord] = []
-        with self._path.open("r", encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                raw = json.loads(line)
-                out.append(QuarantineRecord(**raw))
+        for raw in self._store.read_json_lines():
+            out.append(QuarantineRecord(**raw))
         return out

--- a/src/p2p_oplog_replicator/persistence/file_backend.py
+++ b/src/p2p_oplog_replicator/persistence/file_backend.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from p2p_oplog_replicator.persistence.contracts import AtomicJsonStore, JsonLineAppendStore
+
+
+def _canonical_json(payload: dict) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _fsync_file(path: Path) -> None:
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(path: Path) -> None:
+    fd = os.open(str(path), os.O_RDONLY)
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+class DurableJsonLineFileStore(JsonLineAppendStore):
+    """JSONL append store with flush+fsync and trailing-corruption tolerance."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.touch(exist_ok=True)
+
+    def append_json_line(self, record: dict) -> None:
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(_canonical_json(record) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+
+    def read_json_lines(self) -> list[dict]:
+        rows: list[dict] = []
+        with self._path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    # Tolerate truncated trailing line on crash.
+                    continue
+        return rows
+
+
+class DurableAtomicJsonFileStore(AtomicJsonStore):
+    """Atomic JSON snapshot store using temp-file + os.replace + fsync(dir)."""
+
+    def __init__(self, path: Path, default_payload: dict | None = None) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._default = default_payload or {}
+        if not self._path.exists():
+            self.store_json(self._default)
+
+    def load_json(self) -> dict:
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError):
+            return dict(self._default)
+
+    def store_json(self, payload: dict) -> None:
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp.write_text(_canonical_json(payload), encoding="utf-8")
+        _fsync_file(tmp)
+        os.replace(tmp, self._path)
+        _fsync_dir(self._path.parent)

--- a/src/p2p_oplog_replicator/sync/idempotency/index.py
+++ b/src/p2p_oplog_replicator/sync/idempotency/index.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
+from pathlib import Path
 
+from p2p_oplog_replicator.persistence.file_backend import DurableAtomicJsonFileStore
 from p2p_oplog_replicator.sync.errors import ValidationError, ValidationErrorDetail
 
 
@@ -37,6 +39,36 @@ class EventIdempotencyIndex:
 
     def has(self, event_id: str) -> bool:
         return event_id in self._index
+
+
+class PersistentEventIdempotencyIndex(EventIdempotencyIndex):
+    """Event idempotency index persisted atomically as JSON snapshots."""
+
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self._store = DurableAtomicJsonFileStore(path, default_payload={"records": {}})
+        self._load()
+
+    def register(self, event: dict) -> bool:
+        changed = super().register(event)
+        if changed:
+            self._store.store_json(
+                {
+                    "records": {
+                        event_id: asdict(record)
+                        for event_id, record in sorted(self._index.items())
+                    }
+                }
+            )
+        return changed
+
+    def _load(self) -> None:
+        raw = self._store.load_json().get("records", {})
+        for event_id, record in raw.items():
+            self._index[event_id] = IndexRecord(
+                event_id=str(event_id),
+                payload_hash=str(record["payload_hash"]),
+            )
 
 
 def _payload_hash(event: dict) -> str:

--- a/src/p2p_oplog_replicator/sync/log/event_log.py
+++ b/src/p2p_oplog_replicator/sync/log/event_log.py
@@ -1,32 +1,22 @@
 from __future__ import annotations
 
-import json
 from pathlib import Path
+
+from p2p_oplog_replicator.persistence.file_backend import DurableJsonLineFileStore
 
 
 class AppendOnlyEventLog:
-    """Simple JSONL append-only log for validated events."""
+    """Durable append-only JSONL log for validated events."""
 
     def __init__(self, file_path: Path) -> None:
-        self._path = file_path
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._path.touch(exist_ok=True)
+        self._store = DurableJsonLineFileStore(file_path)
 
     def append(self, event: dict) -> int:
-        with self._path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(event, sort_keys=True, separators=(",", ":")) + "\n")
+        self._store.append_json_line(event)
         return self.count()
 
     def read_all(self) -> list[dict]:
-        out: list[dict] = []
-        with self._path.open("r", encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line:
-                    continue
-                out.append(json.loads(line))
-        return out
+        return self._store.read_json_lines()
 
     def count(self) -> int:
-        with self._path.open("r", encoding="utf-8") as fh:
-            return sum(1 for _ in fh)
+        return len(self.read_all())


### PR DESCRIPTION
## Summary
- Add durable file backend with flush+fsync append and atomic replace snapshots.
- Wire event log, quarantine store, and persistent idempotency index to the backend.

## Issue
- References #45

## Stack
- Base PR: #53
